### PR TITLE
feature/skip-anchor-for-h1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Auto Markdown TOC
+
+WARNING: This is just a temporal fork to fix a bug in the original [huntertran.auto-markdown-toc](https://github.com/huntertran/markdown-toc) extension when inserting the anchors for headers. This extension places the anchors **before** the header. The original extension places them after the header, making them unusable in Bitbucket.
+
 Generate TOC (table of contents) of headlines from parsed [markdown](https://en.wikipedia.org/wiki/Markdown) file.
 
 <!-- TOC depthFrom:2 -->
@@ -6,11 +9,11 @@ Generate TOC (table of contents) of headlines from parsed [markdown](https://en.
 - [1. Features](#1-features)
 - [2. Installation](#2-installation)
 - [3. Usage](#3-usage)
-    - [3.1. Insert TOC](#31-insert-toc)
-    - [3.2. Insert Header Number Sections](#32-insert-header-number-sections)
+  - [3.1. Insert TOC](#31-insert-toc)
+  - [3.2. Insert Header Number Sections](#32-insert-header-number-sections)
 - [4. Configuration](#4-configuration)
-    - [4.1. Default Settings](#41-default-settings)
-    - [4.2. Unique Settings](#42-unique-settings)
+  - [4.1. Default Settings](#41-default-settings)
+  - [4.2. Unique Settings](#42-unique-settings)
 - [5. Contributors](#5-contributors)
 - [6. What's New?](#6-whats-new)
 - [7. Authors](#7-authors)
@@ -20,6 +23,7 @@ Generate TOC (table of contents) of headlines from parsed [markdown](https://en.
 <!-- /TOC -->
 
 ## 1. Features
+
 - Insert header number sections.
 - Auto active plugin on markdown
 - Insert anchor for header `<a id="markdown-header" name="header"></a>`
@@ -31,54 +35,63 @@ Generate TOC (table of contents) of headlines from parsed [markdown](https://en.
 - Anchor support for (github.com|nodejs.org|bitbucket.org|ghost.org|gitlab.com).
 
 ## 2. Installation
-```
+
+```bash
 ext install auto-markdown-toc
 ```
 
 ## 3. Usage
+
 ### 3.1. Insert TOC
+
 ![Insert TOC](img/insert-toc.gif)
 
 ### 3.2. Insert Header Number Sections
+
 **Tips:Section of header is begin with depthFrom**
 
 ![Insert Header Number Sections](img/inser-header-number-sections.gif)
 
 ## 4. Configuration
-|attributes|values|defaults|
-|---|---|---|
-|depthFrom|uint(1-6)|1|
-|depthTo|uint(1-6)|6|
-|bulletCharacter|string|"-"|
-|insertAnchor|bool|false|
-|withLinks|bool|true|
-|orderedList|bool|false|
-|updateOnSave|bool|true|
-|anchorMode|github.com/bitbucket.org/ghost.org/gitlab.com|github.com|
+
+| attributes      | values                                        | defaults   |
+| --------------- | --------------------------------------------- | ---------- |
+| depthFrom       | uint(1-6)                                     | 1          |
+| depthTo         | uint(1-6)                                     | 6          |
+| bulletCharacter | string                                        | "-"        |
+| insertAnchor    | bool                                          | false      |
+| withLinks       | bool                                          | true       |
+| orderedList     | bool                                          | false      |
+| updateOnSave    | bool                                          | true       |
+| anchorMode      | github.com/bitbucket.org/ghost.org/gitlab.com | github.com |
 
 ### 4.1. Default Settings
+
 To change the default configuration settings for the `Auto Markdown TOC` extension, edit the user or workspace settings as described here. The available settings are as follows:
 
-|attributes|values|defaults|
-|---|---|---|
-|markdown-toc.depthFrom|number(1-6)|1|
-|markdown-toc.depthTo|number(1-6)|6|
-|markdown-toc.bulletCharacter|string|"-"|
-|markdown-toc.insertAnchor|bool|false|
-|markdown-toc.withLinks|bool|true|
-|markdown-toc.orderedList|bool|false|
-|markdown-toc.updateOnSave|bool|true|
-|markdown-toc.anchorMode|enum|github.com|
+| attributes                   | values      | defaults   |
+| ---------------------------- | ----------- | ---------- |
+| markdown-toc.depthFrom       | number(1-6) | 1          |
+| markdown-toc.depthTo         | number(1-6) | 6          |
+| markdown-toc.bulletCharacter | string      | "-"        |
+| markdown-toc.insertAnchor    | bool        | false      |
+| markdown-toc.withLinks       | bool        | true       |
+| markdown-toc.orderedList     | bool        | false      |
+| markdown-toc.updateOnSave    | bool        | true       |
+| markdown-toc.anchorMode      | enum        | github.com |
 
 ### 4.2. Unique Settings
+
 If you want to use a unique setting for a file, you can add attributes to `<!-- TOC -->` , just like:
-```
+
+```text
 <!-- TOC depthFrom:2 orderedList:true -->
 
 <!-- /TOC -->
 ```
 
 ## 5. Contributors
+
 - sine sawtooth (Add: Header number section)
 - chriscamicas (Update: Anchor generation)
 - kevindaub (Add : Use workspace settings for tabs and eOL)
@@ -87,22 +100,28 @@ If you want to use a unique setting for a file, you can add attributes to `<!-- 
 - jgroom33 (Fix: Codeblock error)
 - satokaz (Fix: Codeblock error)
 
-## 6. What's New?
-[CHANGELOG](https://github.com/huntertran/markdown-toc/blob/master/CHANGELOG.md)
+## 6. What's New
 
+[CHANGELOG](https://github.com/xavierguarch/markdown-toc/blob/master/CHANGELOG.md)
 
 ## 7. Authors
 
 This forked repository is maintained by me and anyone who would like to contribute. The EOL fixed was contributed by [roborourke](https://github.com/roborourke/markdown-toc.git) and any one open new pull request with the hope of fixing the problem.
 
-The original code is created by Alan Walk. If you have any questions, contact him at:
-- Mail : [alanwalk93@gmail.com](mailto:alanwalk93@gmail.com)
-- Twitter : [@AlanWalk93](https://twitter.com/AlanWalk93)
-- Github : [AlanWalk](https://github.com/AlanWalk)
+The original code was created by Alan Walk, and later updated by Hunter Tran. If you have any questions, contact them at:
+
+- Alan Walk
+  - Mail : [alanwalk93@gmail.com](mailto:alanwalk93@gmail.com)
+  - Twitter : [@AlanWalk93](https://twitter.com/AlanWalk93)
+  - Github : [AlanWalk](https://github.com/AlanWalk)
+- Hunter Tran
+  - Mail : [hunter.tran.92@gmail.com](mailto:hunter.tran.92@gmail.com)
 
 ## 8. License
-The package is Open Source Software released under the [MIT License](LICENSE). It's developed by AlanWalk, maintained by Hunter Tran
+
+The package is Open Source Software released under the [MIT License](LICENSE). It's developed by AlanWalk, maintained by Xavier Guarch
 
 ## 9. Links
-- [Source Code](https://github.com/huntertran/markdown-toc)
-- [Market](https://marketplace.visualstudio.com/items?itemName=huntertran.auto-markdown-toc)
+
+- [Source Code](https://github.com/xavierguarch/markdown-toc)
+- [Market](https://marketplace.visualstudio.com/items?itemName=xavierguarch.auto-markdown-toc)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,336 +1,336 @@
 {
-    "name": "markdown-toc",
-    "version": "1.6.1",
-    "lockfileVersion": 1,
-    "requires": true,
-    "dependencies": {
-        "@babel/code-frame": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-            "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-            "dev": true,
-            "requires": {
-                "@babel/highlight": "^7.0.0"
-            }
-        },
-        "@babel/highlight": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-            "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
-            "dev": true,
-            "requires": {
-                "chalk": "^2.0.0",
-                "esutils": "^2.0.2",
-                "js-tokens": "^4.0.0"
-            }
-        },
-        "@types/node": {
-            "version": "8.10.51",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.51.tgz",
-            "integrity": "sha512-cArrlJp3Yv6IyFT/DYe+rlO8o3SIHraALbBW/+CcCYW/a9QucpLI+n2p4sRxAvl2O35TiecpX2heSZtJjvEO+Q==",
-            "dev": true
-        },
-        "@types/vscode": {
-            "version": "1.36.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.36.0.tgz",
-            "integrity": "sha512-SbHR3Q5g/C3N+Ila3KrRf1rSZiyHxWdOZ7X3yFHXzw6HrvRLuVZrxnwEX0lTBMRpH9LkwZdqRTgXW+D075jxkg==",
-            "dev": true
-        },
-        "anchor-markdown-header": {
-            "version": "0.5.7",
-            "resolved": "https://registry.npmjs.org/anchor-markdown-header/-/anchor-markdown-header-0.5.7.tgz",
-            "integrity": "sha1-BFBj125qH5zTJ6V6ASaqD97Dcac=",
-            "requires": {
-                "emoji-regex": "~6.1.0"
-            }
-        },
-        "ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
-            "requires": {
-                "color-convert": "^1.9.0"
-            }
-        },
-        "argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "requires": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
-        "balanced-match": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
-        },
-        "brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
-            "requires": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "builtin-modules": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-            "dev": true
-        },
-        "chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
-            "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            }
-        },
-        "color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
-            "requires": {
-                "color-name": "1.1.3"
-            }
-        },
-        "color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
-        },
-        "commander": {
-            "version": "2.15.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-            "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-            "dev": true
-        },
-        "concat-map": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
-        },
-        "diff": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-            "dev": true
-        },
-        "emoji-regex": {
-            "version": "6.1.3",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.3.tgz",
-            "integrity": "sha1-7HmjlpsC0uzytyJUJ5v5m8eoOTI="
-        },
-        "escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
-        },
-        "esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true
-        },
-        "esutils": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-            "dev": true
-        },
-        "fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
-        },
-        "glob": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-            "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-            "dev": true,
-            "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            }
-        },
-        "has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true
-        },
-        "inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
-            "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
-        },
-        "js-tokens": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true
-        },
-        "js-yaml": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-            "dev": true,
-            "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            }
-        },
-        "minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
-            "requires": {
-                "brace-expansion": "^1.1.7"
-            }
-        },
-        "minimist": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-            "dev": true
-        },
-        "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "dev": true,
-            "requires": {
-                "minimist": "0.0.8"
-            }
-        },
-        "once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
-            "requires": {
-                "wrappy": "1"
-            }
-        },
-        "path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
-        },
-        "path-parse": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-            "dev": true
-        },
-        "resolve": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-            "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
-            "dev": true,
-            "requires": {
-                "path-parse": "^1.0.6"
-            }
-        },
-        "semver": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-            "dev": true
-        },
-        "sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-            "dev": true
-        },
-        "supports-color": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-            "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-            "dev": true,
-            "requires": {
-                "has-flag": "^3.0.0"
-            }
-        },
-        "tslib": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-            "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-            "dev": true
-        },
-        "tslint": {
-            "version": "5.18.0",
-            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.18.0.tgz",
-            "integrity": "sha512-Q3kXkuDEijQ37nXZZLKErssQVnwCV/+23gFEMROi8IlbaBG6tXqLPQJ5Wjcyt/yHPKBC+hD5SzuGaMora+ZS6w==",
-            "dev": true,
-            "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "builtin-modules": "^1.1.1",
-                "chalk": "^2.3.0",
-                "commander": "^2.12.1",
-                "diff": "^3.2.0",
-                "glob": "^7.1.1",
-                "js-yaml": "^3.13.1",
-                "minimatch": "^3.0.4",
-                "mkdirp": "^0.5.1",
-                "resolve": "^1.3.2",
-                "semver": "^5.3.0",
-                "tslib": "^1.8.0",
-                "tsutils": "^2.29.0"
-            }
-        },
-        "tsutils": {
-            "version": "2.29.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-            "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
-            "dev": true,
-            "requires": {
-                "tslib": "^1.8.1"
-            }
-        },
-        "typescript": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-            "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
-            "dev": true
-        },
-        "wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
-        }
+  "name": "auto-markdown-toc",
+  "version": "2.1.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@types/node": {
+      "version": "8.10.51",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.51.tgz",
+      "integrity": "sha512-cArrlJp3Yv6IyFT/DYe+rlO8o3SIHraALbBW/+CcCYW/a9QucpLI+n2p4sRxAvl2O35TiecpX2heSZtJjvEO+Q==",
+      "dev": true
+    },
+    "@types/vscode": {
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.36.0.tgz",
+      "integrity": "sha512-SbHR3Q5g/C3N+Ila3KrRf1rSZiyHxWdOZ7X3yFHXzw6HrvRLuVZrxnwEX0lTBMRpH9LkwZdqRTgXW+D075jxkg==",
+      "dev": true
+    },
+    "anchor-markdown-header": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/anchor-markdown-header/-/anchor-markdown-header-0.5.7.tgz",
+      "integrity": "sha1-BFBj125qH5zTJ6V6ASaqD97Dcac=",
+      "requires": {
+        "emoji-regex": "~6.1.0"
+      }
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.3.tgz",
+      "integrity": "sha1-7HmjlpsC0uzytyJUJ5v5m8eoOTI="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
+    },
+    "tslint": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.18.0.tgz",
+      "integrity": "sha512-Q3kXkuDEijQ37nXZZLKErssQVnwCV/+23gFEMROi8IlbaBG6tXqLPQJ5Wjcyt/yHPKBC+hD5SzuGaMora+ZS6w==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
+        "diff": "^3.2.0",
+        "glob": "^7.1.1",
+        "js-yaml": "^3.13.1",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.8.0",
+        "tsutils": "^2.29.0"
+      }
+    },
+    "tsutils": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
+    "typescript": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-markdown-toc",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,154 +1,152 @@
 {
-    "name": "auto-markdown-toc",
-    "displayName": "Auto Markdown TOC",
-    "description": "Markdown TOC (Table Of Contents) Plugin for Visual Studio Code.",
-    "version": "2.1.1",
-    "icon": "img/markdown-toc.png",
-    "license": "MIT",
-    "author": {
-        "email": "hunter.tran.92@gmail.com",
-        "name": "Hunter Tran",
-        "url": "https://coding4food.net/"
-    },
-    "bugs": {
-        "url": "https://github.com/huntertran/markdown-toc/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/huntertran/markdown-toc.git"
-    },
-    "keywords": [
-        "markdown",
-        "toc"
+  "name": "auto-markdown-toc",
+  "displayName": "Auto Markdown TOC",
+  "description": "Markdown TOC (Table Of Contents) Plugin for Visual Studio Code.",
+  "version": "2.1.2",
+  "icon": "img/markdown-toc.png",
+  "license": "MIT",
+  "author": {
+    "name": "Xavier Guarch"
+  },
+  "bugs": {
+    "url": "https://github.com/xavierguarch/markdown-toc/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/xavierguarch/markdown-toc.git"
+  },
+  "keywords": [
+    "markdown",
+    "toc"
+  ],
+  "homepage": "https://github.com/xavierguarch/markdown-toc",
+  "publisher": "xavierguarch",
+  "engines": {
+    "vscode": "^1.34.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onLanguage:markdown"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "extension.updateMarkdownToc",
+        "title": "Auto Markdown TOC: Insert/Update"
+      },
+      {
+        "command": "extension.deleteMarkdownToc",
+        "title": "Auto Markdown TOC: Delete"
+      },
+      {
+        "command": "extension.updateMarkdownSections",
+        "title": "Auto Markdown Sections: Insert/Update"
+      },
+      {
+        "command": "extension.deleteMarkdownSections",
+        "title": "Auto Markdown Sections: Delete"
+      }
     ],
-    "homepage": "https://github.com/huntertran/markdown-toc",
-    "publisher": "huntertran",
-    "engines": {
-        "vscode": "^1.34.0"
-    },
-    "categories": [
-        "Other"
-    ],
-    "activationEvents": [
-        "onLanguage:markdown"
-    ],
-    "main": "./out/extension.js",
-    "contributes": {
-        "commands": [
-            {
-                "command": "extension.updateMarkdownToc",
-                "title": "Auto Markdown TOC: Insert/Update"
-            },
-            {
-                "command": "extension.deleteMarkdownToc",
-                "title": "Auto Markdown TOC: Delete"
-            },
-            {
-                "command": "extension.updateMarkdownSections",
-                "title": "Auto Markdown Sections: Insert/Update"
-            },
-            {
-                "command": "extension.deleteMarkdownSections",
-                "title": "Auto Markdown Sections: Delete"
-            }
-        ],
-        "menus": {
-            "editor/context": [
-                {
-                    "when": "editorLangId == 'markdown'",
-                    "command": "extension.updateMarkdownToc"
-                },
-                {
-                    "when": "editorLangId == 'markdown'",
-                    "command": "extension.deleteMarkdownToc"
-                },
-                {
-                    "when": "editorLangId == 'markdown'",
-                    "command": "extension.updateMarkdownSections"
-                },
-                {
-                    "when": "editorLangId == 'markdown'",
-                    "command": "extension.deleteMarkdownSections"
-                }
-            ]
+    "menus": {
+      "editor/context": [
+        {
+          "when": "editorLangId == 'markdown'",
+          "command": "extension.updateMarkdownToc"
         },
-        "keybindings": [
-            {
-                "command": "extension.updateMarkdownToc",
-                "key": "ctrl+m t"
-            },
-            {
-                "command": "extension.updateMarkdownSections",
-                "key": "ctrl+m s"
-            }
-        ],
-        "configuration": {
-            "type": "object",
-            "title": "Markdown TOC configuration",
-            "properties": {
-                "markdown-toc.depthFrom": {
-                    "type": "number",
-                    "default": 1,
-                    "description": "Depth control [1-6]."
-                },
-                "markdown-toc.depthTo": {
-                    "type": "number",
-                    "default": 6,
-                    "description": "Depth control [1-6]."
-                },
-                "markdown-toc.insertAnchor": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Auto insert anchor for link."
-                },
-                "markdown-toc.withLinks": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Auto insert link."
-                },
-                "markdown-toc.orderedList": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Use ordered list (1. ..., 2. ...)."
-                },
-                "markdown-toc.bulletCharacter": {
-                    "type": "string",
-                    "default": "-",
-                    "description": "Bullet character for TOC"
-                },
-                "markdown-toc.updateOnSave": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Auto update on save."
-                },
-                "markdown-toc.anchorMode": {
-                    "type": "string",
-                    "default": "github.com",
-                    "description": "anchor mode.",
-                    "enum": [
-                        "github.com",
-                        "bitbucket.org",
-                        "ghost.org",
-                        "gitlab.com"
-                    ]
-                }
-            }
+        {
+          "when": "editorLangId == 'markdown'",
+          "command": "extension.deleteMarkdownToc"
+        },
+        {
+          "when": "editorLangId == 'markdown'",
+          "command": "extension.updateMarkdownSections"
+        },
+        {
+          "when": "editorLangId == 'markdown'",
+          "command": "extension.deleteMarkdownSections"
         }
+      ]
     },
-    "scripts": {
-        "vscode:prepublish": "npm run compile",
-        "compile": "tsc -p ./",
-        "lint": "tslint -p ./",
-        "watch": "tsc -watch -p ./"
-    },
-    "dependencies": {
-        "anchor-markdown-header": "^0.5.7"
-    },
-    "devDependencies": {
-        "anchor-markdown-header": "^0.5.7",
-        "@types/node": "^8.10.25",
-        "@types/vscode": "^1.34.0",
-        "tslint": "^5.16.0",
-        "typescript": "^3.5.1"
+    "keybindings": [
+      {
+        "command": "extension.updateMarkdownToc",
+        "key": "ctrl+m t"
+      },
+      {
+        "command": "extension.updateMarkdownSections",
+        "key": "ctrl+m s"
+      }
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "Markdown TOC configuration",
+      "properties": {
+        "markdown-toc.depthFrom": {
+          "type": "number",
+          "default": 1,
+          "description": "Depth control [1-6]."
+        },
+        "markdown-toc.depthTo": {
+          "type": "number",
+          "default": 6,
+          "description": "Depth control [1-6]."
+        },
+        "markdown-toc.insertAnchor": {
+          "type": "boolean",
+          "default": false,
+          "description": "Auto insert anchor for link."
+        },
+        "markdown-toc.withLinks": {
+          "type": "boolean",
+          "default": true,
+          "description": "Auto insert link."
+        },
+        "markdown-toc.orderedList": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use ordered list (1. ..., 2. ...)."
+        },
+        "markdown-toc.bulletCharacter": {
+          "type": "string",
+          "default": "-",
+          "description": "Bullet character for TOC"
+        },
+        "markdown-toc.updateOnSave": {
+          "type": "boolean",
+          "default": true,
+          "description": "Auto update on save."
+        },
+        "markdown-toc.anchorMode": {
+          "type": "string",
+          "default": "github.com",
+          "description": "anchor mode.",
+          "enum": [
+            "github.com",
+            "bitbucket.org",
+            "ghost.org",
+            "gitlab.com"
+          ]
+        }
+      }
     }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "lint": "tslint -p ./",
+    "watch": "tsc -watch -p ./"
+  },
+  "dependencies": {
+    "anchor-markdown-header": "^0.5.7"
+  },
+  "devDependencies": {
+    "anchor-markdown-header": "^0.5.7",
+    "@types/node": "^8.10.25",
+    "@types/vscode": "^1.34.0",
+    "tslint": "^5.16.0",
+    "typescript": "^3.5.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "auto-markdown-toc",
   "displayName": "Auto Markdown TOC",
   "description": "Markdown TOC (Table Of Contents) Plugin for Visual Studio Code.",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "icon": "img/markdown-toc.png",
   "license": "MIT",
   "author": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "auto-markdown-toc",
   "displayName": "Auto Markdown TOC",
   "description": "Markdown TOC (Table Of Contents) Plugin for Visual Studio Code.",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "icon": "img/markdown-toc.png",
   "license": "MIT",
   "author": {

--- a/src/AutoMarkdownToc.ts
+++ b/src/AutoMarkdownToc.ts
@@ -159,9 +159,9 @@ export class AutoMarkdownToc {
                     name,
                     '" name="',
                     name,
-                    '"></a>'];
+                    '"></a>\n'];
 
-                let insertPosition = new Position(header.range.end.line, header.range.end.character);
+                let insertPosition = new Position(header.range.start.line, header.range.start.character);
                 editBuilder.insert(insertPosition, text.join(''));
             }
         });

--- a/src/AutoMarkdownToc.ts
+++ b/src/AutoMarkdownToc.ts
@@ -152,19 +152,24 @@ export class AutoMarkdownToc {
         headerList.forEach(header => {
             let anchorMatches = header.hash.match(this.configManager.optionKeys.REGEXP_ANCHOR);
             if (anchorMatches != null) {
-                let name = anchorMatches[1];
-                let text = [
-                    '<a id="markdown-',
-                    name,
-                    '" name="',
-                    name,
-                    '"></a>',
-                    this.configManager.lineEnding,
-                    this.configManager.lineEnding,
-                ];
+                let headerLevel = header.headerMark.length;
+                // Do NOT add an anchor for the first level header,
+                // only for the rest of levels
+                if (headerLevel > 1) {
+                    let name = anchorMatches[1];
+                    let text = [
+                        '<a id="markdown-',
+                        name,
+                        '" name="',
+                        name,
+                        '"></a>',
+                        this.configManager.lineEnding,
+                        this.configManager.lineEnding,
+                    ];
 
-                let insertPosition = new Position(header.range.start.line, 0);
-                editBuilder.insert(insertPosition, text.join(''));
+                    let insertPosition = new Position(header.range.start.line, 0);
+                    editBuilder.insert(insertPosition, text.join(''));
+                }
             }
         });
     }

--- a/src/AutoMarkdownToc.ts
+++ b/src/AutoMarkdownToc.ts
@@ -154,12 +154,14 @@ export class AutoMarkdownToc {
             if (anchorMatches != null) {
                 let name = anchorMatches[1];
                 let text = [
-                    this.configManager.lineEnding,
                     '<a id="markdown-',
                     name,
                     '" name="',
                     name,
-                    '"></a>\n'];
+                    '"></a>',
+                    this.configManager.lineEnding,
+                    this.configManager.lineEnding,
+                ];
 
                 let insertPosition = new Position(header.range.start.line, 0);
                 editBuilder.insert(insertPosition, text.join(''));
@@ -175,7 +177,18 @@ export class AutoMarkdownToc {
                 let lineText = doc.lineAt(index).text;
                 if (lineText.match(this.configManager.optionKeys.REGEXP_MARKDOWN_ANCHOR) == null)
                     continue;
-                let range = new Range(new Position(index, 0), new Position(index + 1, 0));
+                
+                // We check if the line after the anchor is empty,
+                // in which case we will also remove it because our
+                // insertAnchor function inserts a blank line after the
+                // anchor.
+                let endLine = index + 1;
+                let nextLine = doc.lineAt(index + 1).text;
+                if (nextLine.length === 0) {
+                    endLine = index + 2;
+                }
+
+                let range = new Range(new Position(index, 0), new Position(endLine, 0));
                 editBuilder.delete(range);
             }
         }

--- a/src/AutoMarkdownToc.ts
+++ b/src/AutoMarkdownToc.ts
@@ -161,7 +161,7 @@ export class AutoMarkdownToc {
                     name,
                     '"></a>\n'];
 
-                let insertPosition = new Position(header.range.start.line, header.range.start.character);
+                let insertPosition = new Position(header.range.start.line, 0);
                 editBuilder.insert(insertPosition, text.join(''));
             }
         });


### PR DESCRIPTION
When setting `markdown-toc.depthFrom=2` do not generate an anchor before the H1 title. This way, the document will meet [MD041 - First line in file should be a top level heading](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md041---first-line-in-file-should-be-a-top-level-heading). Thanks (:


