### PR TITLE
Fixed issue #20 with orderlist disable issue

### DIFF
--- a/src/AutoMarkdownToc.ts
+++ b/src/AutoMarkdownToc.ts
@@ -64,7 +64,7 @@ export class AutoMarkdownToc {
                 autoMarkdownToc.deleteAnchors(editBuilder);
             }
 
-            if (this.configManager.options.DETECT_AUTO_SET_SECTION.value && this.configManager.options.isOrderedListDetected) {
+            if (this.configManager.options.DETECT_AUTO_SET_SECTION.value) { // } && this.configManager.options.isOrderedListDetected) {
                 autoMarkdownToc.updateHeadersWithSections(editBuilder, headerList, document);
 
                 //rebuild header list, because headers have changed
@@ -102,7 +102,11 @@ export class AutoMarkdownToc {
                 editBuilder.insert(new Position(header.range.start.line, 0), this.configManager.options.lineEnding);
             }
 
-            editBuilder.replace(header.range, header.fullHeaderWithOrder);
+            const useHeaderNumbers =  this.configManager.options.ORDERED_LIST.value;
+            editBuilder.replace(header.range, 
+                useHeaderNumbers
+                ? header.fullHeaderWithOrder        // orderedlist=true so update the headers with numbers
+                : header.fullHeaderWithoutOrder);   // orderedlist=true so NO header numbers
         });
     }
 


### PR DESCRIPTION
When the orderlist is false the document headers were still being numbered.  This cause the TOC and document header to be miss-matched

