### PR TITLE
Add feature to ignore header

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ Generate TOC (table of contents) of headlines from parsed [markdown](https://en.
 - [1. Features](#1-features)
 - [2. Installation](#2-installation)
 - [3. Usage](#3-usage)
-    - [3.1. Insert TOC](#31-insert-toc)
-    - [3.2. Insert Header Number Sections](#32-insert-header-number-sections)
+  - [3.1. Insert TOC](#31-insert-toc)
+  - [3.2. Insert Header Number Sections](#32-insert-header-number-sections)
+  - [3.3. Ignore Header](#33-ignore-header)
 - [4. Configuration](#4-configuration)
-    - [4.1. Default Settings](#41-default-settings)
-    - [4.2. Unique Settings](#42-unique-settings)
+  - [4.1. Default Settings](#41-default-settings)
+  - [4.2. Unique Settings](#42-unique-settings)
 - [5. Contributors](#5-contributors)
 - [6. What's New?](#6-whats-new)
 - [7. Authors](#7-authors)
@@ -58,6 +59,17 @@ ext install auto-markdown-toc
 **Tips:Section of header is begin with depthFrom**
 
 ![Insert Header Number Sections](img/insert-header-number-sections.gif)
+
+## 3.3. Ignore Header
+<a id="markdown-ignore-header" name="ignore-header"></a>
+To ignore a header, you can add the line `<!-- TOC ignore:true -->` above the header to be ignored.
+
+```
+<!-- TOC ignore:true -->
+# Header to be ignored
+
+# Header that should not be ingored
+```
 
 # 4. Configuration
 <a id="markdown-configuration" name="configuration"></a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "auto-markdown-toc",
-    "version": "3.0.1",
+    "version": "3.0.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -153,7 +153,6 @@
         "anchor-markdown-header": "^0.5.7"
     },
     "devDependencies": {
-        "anchor-markdown-header": "^0.5.7",
         "@types/node": "^8.10.25",
         "@types/vscode": "^1.34.0",
         "tslint": "^5.16.0",

--- a/src/AutoMarkdownToc.ts
+++ b/src/AutoMarkdownToc.ts
@@ -159,7 +159,7 @@ export class AutoMarkdownToc {
         for (let index = 0; index < doc.lineCount; index++) {
             let lineText = doc.lineAt(index).text;
 
-            if ((start == undefined) && (lineText.match(RegexStrings.Instance.REGEXP_TOC_START))) {
+            if ((start == undefined) && (lineText.match(RegexStrings.Instance.REGEXP_TOC_START) && !lineText.match(RegexStrings.Instance.REGEXP_IGNORE_TITLE))) {
                 start = new Position(index, 0);
             }
             else if (lineText.match(RegexStrings.Instance.REGEXP_TOC_STOP)) {

--- a/src/HeaderManager.ts
+++ b/src/HeaderManager.ts
@@ -41,6 +41,11 @@ export class HeaderManager {
 
                 let lineText = doc.lineAt(index).text;
 
+                if (RegexStrings.Instance.REGEXP_IGNORE_TITLE.test(lineText)) {
+                    index += 1
+                    continue
+                }
+
                 let header = this.getHeader(lineText);
 
                 if (header.isHeader) {


### PR DESCRIPTION
Adds a feature to ignore a Header line if the preceding line has the tag `<!-- TOC ignore:true -->`.

E.g.:

```pandoc
<!-- TOC ignore:true -->
# Header to be ignored

# Header that should not be ingored
```

This will result in:

```pandoc
<!-- TOC -->

- [Header that should not be ingored](#header-that-should-not-be-ingored)

<!-- /TOC -->
```