### PR TITLE
Fix #56: clamp line index after a closing code fence

### DIFF
--- a/src/TocManager.ts
+++ b/src/TocManager.ts
@@ -34,6 +34,10 @@ export class TocManager {
                 index = Utilities.getNextLineIndexIsNotInCode(index, doc);
             }
 
+            if (index < 0 || index >= doc.lineCount) {
+                break;
+            }
+
             let lineText = doc.lineAt(index).text;
 
             if ((start === undefined) && (lineText.match(RegexStrings.Instance.REGEXP_TOC_START) && !lineText.match(RegexStrings.Instance.REGEXP_IGNORE_TITLE))) {

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -5,7 +5,7 @@ export class Utilities {
     public static getNextLineIndexIsNotInCode(index: number, doc: TextDocument) {
         for (let currentLineIndex = index + 1; currentLineIndex < doc.lineCount; currentLineIndex++) {
             if (this.isLineStartOrEndOfCodeBlock(currentLineIndex, doc)) {
-                return currentLineIndex + 1;
+                return Math.min(currentLineIndex + 1, doc.lineCount - 1);
             }
         }
 


### PR DESCRIPTION
Fixes #56.

`scanForTocRange()` passes the return value of `getNextLineIndexIsNotInCode()`
straight into `doc.lineAt()`. When a code fence is the last line of the
document, that helper returns `doc.lineCount`, which `lineAt()` rejects with
``Illegal value for `line` ``.

Reproducer: any markdown file whose final line is ``` or ~~~ with no trailing
newline. A trailing newline exposes a final empty line, keeping the index in
range — which is why this reads as intermittent and why #56 sat unreproduced.
